### PR TITLE
Always check and define selected shortcut in shortcutsComputed

### DIFF
--- a/src/date-picker.js
+++ b/src/date-picker.js
@@ -193,29 +193,33 @@ export default {
         if (shortcuts.length > 0)
           this.customShortcutInserted = shortcuts[shortcuts.length - 1].custom;
 
+        let shortcutSelected = false;
+
+        if (!this.isCustomSelected) {
+          const formatedCurrentValue = this.currentValue.map(item => {
+            return `${item.getDate()}/${item.getMonth()}/${item.getFullYear()}`;
+          });
+          shortcuts.forEach((shortcut, index) => {
+            const formatedShortcutValue =
+              typeof shortcut.onClick(this) !== 'undefined'
+                ? shortcut.onClick(this).map(item => {
+                    return `${item.getDate()}/${item.getMonth()}/${item.getFullYear()}`;
+                  })
+                : '';
+            shortcut.selected =
+              formatedCurrentValue.toString() === formatedShortcutValue.toString();
+
+            if (shortcut.selected) {
+              this.isCustom = false;
+              shortcutSelected = true;
+              this.currentShortcut = index;
+            }
+          });
+        }
+
         if (!this.customShortcutInserted) {
-          let shortcutSelected = false;
-
-          if (!this.isCustomSelected) {
-            const formatedCurrentValue = this.currentValue.map(item => {
-              return `${item.getDate()}/${item.getMonth()}/${item.getFullYear()}`;
-            });
-            shortcuts.forEach((shortcut, index) => {
-              const formatedShortcutValue = shortcut.onClick(this).map(item => {
-                return `${item.getDate()}/${item.getMonth()}/${item.getFullYear()}`;
-              });
-              shortcut.selected =
-                formatedCurrentValue.toString() === formatedShortcutValue.toString();
-
-              if (shortcut.selected) {
-                this.isCustom = false;
-                shortcutSelected = true;
-                this.currentShortcut = index;
-              }
-            });
-          }
-
           this.customShortcutInserted = true;
+          if (!this.currentShortcut) this.currentShortcut = shortcuts.length;
           shortcuts.push({
             text: this.shortcuts.customShortcutText ? this.shortcuts.customShortcutText : 'Custom',
             onClick() {},


### PR DESCRIPTION
Fixed issues:

- When custom was selected, button active doesn't appear when reload page (for cached values);
- When value is loaded from api and cache is clear, button active was set in custom in first opening.