### PR TITLE
PAN-6210 refactor maxDaysRange prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [2.0.12](https://github.com/huggydigital/huggy-datepicker/compare/v1.2.0...v2.0.12) (2025-05-13)
 ## [2.0.13](https://github.com/HuggyDigital/huggy-datepicker/pull/12/commits/0f9e85d175cbdb61ebd7e7e521c5cd44432cc42e) (2025-06-14)
+## [2.0.14](https://github.com/HuggyDigital/huggy-datepicker/compare/PAN-6162...PAN-6210) (2025-08-01)
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ You can also override some of the default locale by `lang`.
 | prefix-class                   | set prefix class                                                      | `string`                                        | 'mx'           |
 | scroll-duration                | set the duration of scroll when hour is selected                      | `number`                                        | 100            |
 | column-calendar                | set if calendar range display direction is column                     | `boolean`                                       | false          |
-| max-days-range                 | set max range warning for shortcut datepicker custom                  | `object { days: Number, text: string }`         | null           |
+| max-days-range                 | Set validation rules for date ranges. Use an object to combine day limits and custom validation functions.                  | `{ days?: { limit: number, text: string }, custom?: { validate: function, text: string } }` \|  `function`  | null           |
 | time-labels                 | shows labels for time-picker columns                  | `object { hour?: string, minute?: string, second?: string }`         | null           |
 
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ You can also override some of the default locale by `lang`.
 | prefix-class                   | set prefix class                                                      | `string`                                        | 'mx'           |
 | scroll-duration                | set the duration of scroll when hour is selected                      | `number`                                        | 100            |
 | column-calendar                | set if calendar range display direction is column                     | `boolean`                                       | false          |
-| max-days-range                 | Set validation rules for date ranges. Use an object to combine day limits and custom validation functions.                  | `{ days?: { limit: number, text: string }, custom?: { validate: function, text: string } }` \|  `function`  | null           |
+| max-days-range                 | Sets an array of validation rules for the date range                  | `[{ days?: number, validate?: function, text: string }]` | null           |
 | time-labels                 | shows labels for time-picker columns                  | `object { hour?: string, minute?: string, second?: string }`         | null           |
 
 

--- a/__tests__/__snapshots__/DatePicker.test.ts.snap
+++ b/__tests__/__snapshots__/DatePicker.test.ts.snap
@@ -611,6 +611,7 @@ exports[`DatePicker prop: appendToBody = false 1`] = `
                     </table>
                   </div>
                 </div>
+                <!---->
               </div>
             </div>
           </div>
@@ -1238,6 +1239,7 @@ exports[`DatePicker prop: appendToBody = true 1`] = `
                 </table>
               </div>
             </div>
+            <!---->
           </div>
         </div>
       </div>

--- a/lib/Picker.tsx
+++ b/lib/Picker.tsx
@@ -55,6 +55,7 @@ export interface PickerBaseProps {
   isCustomSelected?: boolean;
   shortcutsCalendarAlwaysOpen?: boolean;
   columnCalendar?: boolean;
+  titleFormat?: string;
   maxDaysRange?:
     | RangeValidationConfig
     | { days: number; text: string }
@@ -683,6 +684,7 @@ const pickerbaseProps = keys<PickerBaseProps>()([
   'isCustomSelected',
   'shortcutsCalendarAlwaysOpen',
   'columnCalendar',
+  'titleFormat',
   'maxDaysRange',
   'timeLabels',
   'onOpen',

--- a/lib/Picker.tsx
+++ b/lib/Picker.tsx
@@ -51,7 +51,7 @@ export interface PickerBaseProps {
   shortcutsCalendarAlwaysOpen?: boolean;
   columnCalendar?: boolean;
   titleFormat?: string;
-  maxDaysRange?: RangeValidationConfig;
+  maxDaysRange?: RangeValidationConfig[] | RangeValidationConfig;
   timeLabels?: TimeLabels;
   disabledDate?: (v: Date) => boolean;
   disabledTime?: (v: Date) => boolean;

--- a/lib/style/index.scss
+++ b/lib/style/index.scss
@@ -264,6 +264,12 @@
       background-color: $persian-blue-300;
     }
 
+    &:disabled {
+      background-color: #EAE9ED;
+      color: #ABA9B0;
+      cursor: not-allowed;
+    }
+
     &:active,
     &:focus-visible {
       background-color: $persian-blue-700;
@@ -286,28 +292,27 @@
 
 .#{$namespace}-footer-warning {
   display: flex;
-  justify-content: center;
-  align-items: center;
+  align-items: start;
+  max-width: 388px;
 
-  background: #f8f8f8;
+  background: #EFEFF2;
   border: 1px solid #e1e1e1;
   border-radius: 8px;
-  padding: 7px 16px;
-  margin: 0 16px 0 auto;
-  color: #191d27;
+  padding: 8px;
+  margin: 0 16px 16px 16px;
+  color: #4C4B4F;
   font-size: 12px;
   line-height: 16px;
   letter-spacing: 0.4px;
+  text-align: left;
 
   span {
     display: flex;
     align-items: center;
     text-align: left;
-
-    &.icon {
-      margin-right: 8px;
-    }
+    margin-left: 8px;
   }
+
   & + .#{$namespace}-datepicker-btn-confirm {
     margin: 0;
     pointer-events: none;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@huggydigital/huggy-datepicker",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "A Datepicker Component For Vue 3",
   "main": "./index.js",
   "module": "./index.es.js",


### PR DESCRIPTION
Mudanças realizadas:

- A prop `max-days-range` agora pode ser usada como um objeto para combinar limites de dias e funções de validação personalizadas.
- As mensagens de erro aparecem abaixo do calendário e são acumulativas

Exemplo de uso:

```js
computed: {
    validationConfig() {
      return {
        {
          days: 10,
          text: 'Não é permitido selecionar mais que 10 dias.',
        },
        {
          validate: this.isInvalidDateSelection,
          text: 'Por causa das mudanças na API, não é permitido selecionar datas dos meses de junho e julho de 2025 ao mesmo tempo.',
        },
      };
    },
  },
  methods: {
    isInvalidDateSelection(range) {
      const [startDate, endDate] = range;

      if (!endDate) {
        return true;
      }

      return !(
        startDate.getFullYear() === 2025 &&
        startDate.getMonth() === 5 &&
        endDate.getFullYear() === 2025 &&
        endDate.getMonth() === 6
      );
    },
   }
```

```html
<date-picker
        // outras props
        :max-days-range="validationConfig">
</date-picker>
```